### PR TITLE
Update the Dockerfile to use downstream images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
-FROM gcr.io/distroless/static:debug-nonroot
-WORKDIR /
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 
-COPY manager manager
-EXPOSE 8080
+WORKDIR /build
+COPY . .
+RUN make build
+
+FROM registry.ci.openshift.org/ocp/4.12:base
+
+COPY --from=builder /build/bin/manager /bin
+USER 1001
+
+LABEL io.k8s.display-name="OpenShift Platform Operator Manager" \
+      io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of platform operators." \
+      io.openshift.tags="openshift" \
+      summary="This is a component of OpenShift Container Platform and manages the lifecycle of platform operators." \
+      maintainer="Odin Team <aos-odin@redhat.com>"

--- a/test/e2e/platform_operators_test.go
+++ b/test/e2e/platform_operators_test.go
@@ -159,7 +159,7 @@ var _ = Describe("platform operators controller", func() {
 					if err := c.Get(ctx, types.NamespacedName{Name: po.GetName()}, bi); err != nil {
 						return nil, err
 					}
-					if bi.Status.InstalledBundleName == "" {
+					if bi.Status.ActiveBundle == "" {
 						return nil, fmt.Errorf("waiting for bundle name to be populated")
 					}
 					return meta.FindStatusCondition(bi.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil


### PR DESCRIPTION
Update dockerfile and use the rhel-related base images. Run the build Makefile target in the builder image and copy that PO manager executable into the final image layer.