### PR TITLE
Introduce the PO manager CVO manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.12:base
 
+ADD manifests/ /manifests
+LABEL io.openshift.release.operator=true
+
 COPY --from=builder /build/bin/manager /bin
 USER 1001
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
 	$(CONTROLLER_GEN) rbac:roleName=manager-role paths=./... output:rbac:artifacts:config=config/rbac
 
+RBAC_LIST = rbac.authorization.k8s.io_v1_clusterrole_platform-operators-manager-role.yaml \
+	rbac.authorization.k8s.io_v1_clusterrole_platform-operators-metrics-reader.yaml \
+	rbac.authorization.k8s.io_v1_clusterrole_platform-operators-proxy-role.yaml \
+	rbac.authorization.k8s.io_v1_clusterrolebinding_platform-operators-manager-rolebinding.yaml \
+	rbac.authorization.k8s.io_v1_clusterrolebinding_platform-operators-proxy-rolebinding.yaml \
+	rbac.authorization.k8s.io_v1_role_platform-operators-leader-election-role.yaml \
+	rbac.authorization.k8s.io_v1_rolebinding_platform-operators-leader-election-rolebinding.yaml
+
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
 manifests: generate kustomize
@@ -61,12 +69,13 @@ manifests: generate kustomize
 	mv $(TMP_DIR)/apiextensions.k8s.io_v1_customresourcedefinition_platformoperators.platform.openshift.io.yaml manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
 	mv $(TMP_DIR)/v1_namespace_openshift-platform-operators-system.yaml manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
 	mv $(TMP_DIR)/v1_serviceaccount_platform-operators-controller-manager.yaml manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
+	mv $(TMP_DIR)/v1_service_platform-operators-controller-manager-metrics-service.yaml manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
 	mv $(TMP_DIR)/apps_v1_deployment_platform-operators-controller-manager.yaml manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
 
 	@# cluster-platform-operator-manager rbacs
 	rm -f manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml
-	for rbac in $(TMP_DIR)/rbac.*; do \
-		cat $${rbac} >> manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml ;\
+	for rbac in $(RBAC_LIST); do \
+		cat $(TMP_DIR)/$${rbac} >> manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml ;\
 		echo '---' >> manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml ;\
 	done
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: platform-operators-system
+namespace: openshift-platform-operators-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: openshift-platform-operators-system

--- a/manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
@@ -1,0 +1,93 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: platformoperators.platform.openshift.io
+spec:
+  group: platform.openshift.io
+  names:
+    kind: PlatformOperator
+    listKind: PlatformOperatorList
+    plural: platformoperators
+    shortNames:
+    - platform
+    - platforms
+    singular: platformoperator
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PlatformOperator is the Schema for the platformoperators API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlatformOperatorSpec defines the desired state of PlatformOperator
+            properties:
+              packageName:
+                description: PackageName specifies the name of the package to be installed from the provided CatalogSource. PackageName is required and must equal the exact name of the package in the catalog.
+                type: string
+            required:
+            - packageName
+            type: object
+          status:
+            description: PlatformOperatorStatus defines the observed state of PlatformOperator
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system

--- a/manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: platform-operators-controller-manager-metrics-service
+  namespace: openshift-platform-operators-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml
@@ -1,30 +1,4 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: platform-operators-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: platform-operators-manager-role
-subjects:
-- kind: ServiceAccount
-  name: platform-operators-controller-manager
-  namespace: openshift-platform-operators-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: platform-operators-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: platform-operators-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: platform-operators-controller-manager
-  namespace: openshift-platform-operators-system
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
@@ -118,14 +92,26 @@ rules:
   - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: platform-operators-leader-election-rolebinding
-  namespace: openshift-platform-operators-system
+  name: platform-operators-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: platform-operators-leader-election-role
+  kind: ClusterRole
+  name: platform-operators-manager-role
+subjects:
+- kind: ServiceAccount
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: platform-operators-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: platform-operators-proxy-role
 subjects:
 - kind: ServiceAccount
   name: platform-operators-controller-manager
@@ -168,4 +154,18 @@ rules:
   verbs:
   - create
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-operators-leader-election-rolebinding
+  namespace: openshift-platform-operators-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: platform-operators-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system
 ---

--- a/manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_05_rbac.yaml
@@ -1,0 +1,171 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: platform-operators-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: platform-operators-manager-role
+subjects:
+- kind: ServiceAccount
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: platform-operators-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: platform-operators-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: platform-operators-manager-role
+rules:
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - platform.openshift.io
+  resources:
+  - platformoperators
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - platform.openshift.io
+  resources:
+  - platformoperators/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - platform.openshift.io
+  resources:
+  - platformoperators/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: platform-operators-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: platform-operators-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-operators-leader-election-rolebinding
+  namespace: openshift-platform-operators-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: platform-operators-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: platform-operators-leader-election-role
+  namespace: openshift-platform-operators-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---

--- a/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: platform-operators-controller-manager
+  namespace: openshift-platform-operators-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: platform-operators-controller-manager
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Adds a root manifests directory which the CVO will use to deploy the PO manager component.

There's some follow-up work once this initial work lands:

- Add the rukpak manifests to the repository
- Add the manifests/image-references file
- Add the downstream rukpak image to the manifests/image-references file
- Add the downstream kube-rbac-proxy to the manfiests/image-references file
- Substitutes the CI built image before running the PO e2e suite
