### PR TITLE
Dockerfile: Remove the io.openshift.release.operator label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN make build
 FROM registry.ci.openshift.org/ocp/4.12:base
 
 ADD manifests/ /manifests
-LABEL io.openshift.release.operator=true
+# LABEL io.openshift.release.operator=true
 
 COPY --from=builder /build/bin/manager /bin
 USER 1001


### PR DESCRIPTION
Temporarily comment out the io.openshift.release.operator Dockerfile label while this repository is still being onboarded to the OCP payload.