### PR TITLE
feat: introduce rukpak manifests into source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,11 @@ RBAC_LIST = rbac.authorization.k8s.io_v1_clusterrole_platform-operators-manager-
 .PHONY: manifests
 manifests: generate kustomize
 	$(KUSTOMIZE) build config/default -o $(TMP_DIR)/
+	$(KUSTOMIZE) build config/rukpak -o $(TMP_DIR)/rukpak.yaml
 	ls $(TMP_DIR)
 
 	@# now rename/join the output files into the files we expect
+	mv $(TMP_DIR)/rukpak.yaml manifests/0000_50_cluster-platform-operator-manager_00-rukpak.yaml
 	mv $(TMP_DIR)/apiextensions.k8s.io_v1_customresourcedefinition_platformoperators.platform.openshift.io.yaml manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
 	mv $(TMP_DIR)/v1_namespace_openshift-platform-operators-system.yaml manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
 	mv $(TMP_DIR)/v1_serviceaccount_platform-operators-controller-manager.yaml manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml

--- a/config/rukpak/apis/crds/core.rukpak.io_bundledeployments.yaml
+++ b/config/rukpak/apis/crds/core.rukpak.io_bundledeployments.yaml
@@ -1,0 +1,306 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: bundledeployments.core.rukpak.io
+spec:
+  group: core.rukpak.io
+  names:
+    kind: BundleDeployment
+    listKind: BundleDeploymentList
+    plural: bundledeployments
+    shortNames:
+    - bd
+    - bds
+    singular: bundledeployment
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.activeBundle
+      name: Active Bundle
+      type: string
+    - jsonPath: .status.conditions[?(.type=="Installed")].reason
+      name: Install State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BundleDeployment is the Schema for the bundledeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BundleDeploymentSpec defines the desired state of BundleDeployment
+            properties:
+              provisionerClassName:
+                description: ProvisionerClassName sets the name of the provisioner
+                  that should reconcile this BundleDeployment.
+                type: string
+              template:
+                description: Template describes the generated Bundle that this deployment
+                  will manage.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the Bundle.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      provisionerClassName:
+                        description: ProvisionerClassName sets the name of the provisioner
+                          that should reconcile this BundleDeployment.
+                        type: string
+                      source:
+                        description: Source defines the configuration for the underlying
+                          Bundle content.
+                        properties:
+                          git:
+                            description: Git is the git repository that backs the
+                              content of this Bundle.
+                            properties:
+                              auth:
+                                description: Auth configures the authorization method
+                                  if necessary.
+                                properties:
+                                  insecureSkipVerify:
+                                    description: InsecureSkipVerify controls whether
+                                      a client verifies the server's certificate chain
+                                      and host name. If InsecureSkipVerify is true,
+                                      the clone operation will accept any certificate
+                                      presented by the server and any host name in
+                                      that certificate. In this mode, TLS is susceptible
+                                      to machine-in-the-middle attacks unless custom
+                                      verification is used. This should be used only
+                                      for testing.
+                                    type: boolean
+                                  secret:
+                                    description: Secret contains reference to the
+                                      secret that has authorization information and
+                                      is in the namespace that the provisioner is
+                                      deployed. The secret is expected to contain
+                                      `data.username` and `data.password` for the
+                                      username and password, respectively for http(s)
+                                      scheme. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+                                      The secret is expected to contain `data.ssh-privatekey`
+                                      and `data.ssh-knownhosts` for the ssh privatekey
+                                      and the host entry in the known_hosts file respectively
+                                      for ssh authorization. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                    type: object
+                                type: object
+                              directory:
+                                description: Directory refers to the location of the
+                                  bundle within the git repository. Directory is optional
+                                  and if not set defaults to ./manifests.
+                                type: string
+                              ref:
+                                description: Ref configures the git source to clone
+                                  a specific branch, tag, or commit from the specified
+                                  repo. Ref is required, and exactly one field within
+                                  Ref is required. Setting more than one field or
+                                  zero fields will result in an error.
+                                properties:
+                                  branch:
+                                    description: Branch refers to the branch to checkout
+                                      from the repository. The Branch should contain
+                                      the bundle manifests in the specified directory.
+                                    type: string
+                                  commit:
+                                    description: Commit refers to the commit to checkout
+                                      from the repository. The Commit should contain
+                                      the bundle manifests in the specified directory.
+                                    type: string
+                                  tag:
+                                    description: Tag refers to the tag to checkout
+                                      from the repository. The Tag should contain
+                                      the bundle manifests in the specified directory.
+                                    type: string
+                                type: object
+                              repository:
+                                description: Repository is a URL link to the git repository
+                                  containing the bundle. Repository is required and
+                                  the URL should be parsable by a standard git tool.
+                                type: string
+                            required:
+                            - ref
+                            - repository
+                            type: object
+                          image:
+                            description: Image is the bundle image that backs the
+                              content of this bundle.
+                            properties:
+                              pullSecret:
+                                description: ImagePullSecretName contains the name
+                                  of the image pull secret in the namespace that the
+                                  provisioner is deployed.
+                                type: string
+                              ref:
+                                description: Ref contains the reference to a container
+                                  image containing Bundle contents.
+                                type: string
+                            required:
+                            - ref
+                            type: object
+                          local:
+                            description: Local is a reference to a local object in
+                              the cluster.
+                            properties:
+                              configMap:
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                required:
+                                - name
+                                - namespace
+                                type: object
+                            required:
+                            - configMap
+                            type: object
+                          type:
+                            description: Type defines the kind of Bundle content being
+                              sourced.
+                            type: string
+                          upload:
+                            description: Upload is a source that enables this Bundle's
+                              content to be uploaded via Rukpak's bundle upload service.
+                              This source type is primarily useful with bundle development
+                              workflows because it enables bundle developers to inject
+                              a local bundle directly into the cluster.
+                            type: object
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - provisionerClassName
+                    - source
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - provisionerClassName
+            - template
+            type: object
+          status:
+            description: BundleDeploymentStatus defines the observed state of BundleDeployment
+            properties:
+              activeBundle:
+                type: string
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/rukpak/apis/crds/core.rukpak.io_bundles.yaml
+++ b/config/rukpak/apis/crds/core.rukpak.io_bundles.yaml
@@ -1,0 +1,385 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: bundles.core.rukpak.io
+spec:
+  group: core.rukpak.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.source.type
+      name: Type
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.resolvedSource
+      name: Resolved Source
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Bundle is the Schema for the bundles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BundleSpec defines the desired state of Bundle
+            properties:
+              provisionerClassName:
+                description: ProvisionerClassName sets the name of the provisioner
+                  that should reconcile this BundleDeployment.
+                type: string
+              source:
+                description: Source defines the configuration for the underlying Bundle
+                  content.
+                properties:
+                  git:
+                    description: Git is the git repository that backs the content
+                      of this Bundle.
+                    properties:
+                      auth:
+                        description: Auth configures the authorization method if necessary.
+                        properties:
+                          insecureSkipVerify:
+                            description: InsecureSkipVerify controls whether a client
+                              verifies the server's certificate chain and host name.
+                              If InsecureSkipVerify is true, the clone operation will
+                              accept any certificate presented by the server and any
+                              host name in that certificate. In this mode, TLS is
+                              susceptible to machine-in-the-middle attacks unless
+                              custom verification is used. This should be used only
+                              for testing.
+                            type: boolean
+                          secret:
+                            description: Secret contains reference to the secret that
+                              has authorization information and is in the namespace
+                              that the provisioner is deployed. The secret is expected
+                              to contain `data.username` and `data.password` for the
+                              username and password, respectively for http(s) scheme.
+                              Refer to https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+                              The secret is expected to contain `data.ssh-privatekey`
+                              and `data.ssh-knownhosts` for the ssh privatekey and
+                              the host entry in the known_hosts file respectively
+                              for ssh authorization. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                        type: object
+                      directory:
+                        description: Directory refers to the location of the bundle
+                          within the git repository. Directory is optional and if
+                          not set defaults to ./manifests.
+                        type: string
+                      ref:
+                        description: Ref configures the git source to clone a specific
+                          branch, tag, or commit from the specified repo. Ref is required,
+                          and exactly one field within Ref is required. Setting more
+                          than one field or zero fields will result in an error.
+                        properties:
+                          branch:
+                            description: Branch refers to the branch to checkout from
+                              the repository. The Branch should contain the bundle
+                              manifests in the specified directory.
+                            type: string
+                          commit:
+                            description: Commit refers to the commit to checkout from
+                              the repository. The Commit should contain the bundle
+                              manifests in the specified directory.
+                            type: string
+                          tag:
+                            description: Tag refers to the tag to checkout from the
+                              repository. The Tag should contain the bundle manifests
+                              in the specified directory.
+                            type: string
+                        type: object
+                      repository:
+                        description: Repository is a URL link to the git repository
+                          containing the bundle. Repository is required and the URL
+                          should be parsable by a standard git tool.
+                        type: string
+                    required:
+                    - ref
+                    - repository
+                    type: object
+                  image:
+                    description: Image is the bundle image that backs the content
+                      of this bundle.
+                    properties:
+                      pullSecret:
+                        description: ImagePullSecretName contains the name of the
+                          image pull secret in the namespace that the provisioner
+                          is deployed.
+                        type: string
+                      ref:
+                        description: Ref contains the reference to a container image
+                          containing Bundle contents.
+                        type: string
+                    required:
+                    - ref
+                    type: object
+                  local:
+                    description: Local is a reference to a local object in the cluster.
+                    properties:
+                      configMap:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - configMap
+                    type: object
+                  type:
+                    description: Type defines the kind of Bundle content being sourced.
+                    type: string
+                  upload:
+                    description: Upload is a source that enables this Bundle's content
+                      to be uploaded via Rukpak's bundle upload service. This source
+                      type is primarily useful with bundle development workflows because
+                      it enables bundle developers to inject a local bundle directly
+                      into the cluster.
+                    type: object
+                required:
+                - type
+                type: object
+            required:
+            - provisionerClassName
+            - source
+            type: object
+          status:
+            description: BundleStatus defines the observed state of Bundle
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentURL:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+              resolvedSource:
+                properties:
+                  git:
+                    description: Git is the git repository that backs the content
+                      of this Bundle.
+                    properties:
+                      auth:
+                        description: Auth configures the authorization method if necessary.
+                        properties:
+                          insecureSkipVerify:
+                            description: InsecureSkipVerify controls whether a client
+                              verifies the server's certificate chain and host name.
+                              If InsecureSkipVerify is true, the clone operation will
+                              accept any certificate presented by the server and any
+                              host name in that certificate. In this mode, TLS is
+                              susceptible to machine-in-the-middle attacks unless
+                              custom verification is used. This should be used only
+                              for testing.
+                            type: boolean
+                          secret:
+                            description: Secret contains reference to the secret that
+                              has authorization information and is in the namespace
+                              that the provisioner is deployed. The secret is expected
+                              to contain `data.username` and `data.password` for the
+                              username and password, respectively for http(s) scheme.
+                              Refer to https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+                              The secret is expected to contain `data.ssh-privatekey`
+                              and `data.ssh-knownhosts` for the ssh privatekey and
+                              the host entry in the known_hosts file respectively
+                              for ssh authorization. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                        type: object
+                      directory:
+                        description: Directory refers to the location of the bundle
+                          within the git repository. Directory is optional and if
+                          not set defaults to ./manifests.
+                        type: string
+                      ref:
+                        description: Ref configures the git source to clone a specific
+                          branch, tag, or commit from the specified repo. Ref is required,
+                          and exactly one field within Ref is required. Setting more
+                          than one field or zero fields will result in an error.
+                        properties:
+                          branch:
+                            description: Branch refers to the branch to checkout from
+                              the repository. The Branch should contain the bundle
+                              manifests in the specified directory.
+                            type: string
+                          commit:
+                            description: Commit refers to the commit to checkout from
+                              the repository. The Commit should contain the bundle
+                              manifests in the specified directory.
+                            type: string
+                          tag:
+                            description: Tag refers to the tag to checkout from the
+                              repository. The Tag should contain the bundle manifests
+                              in the specified directory.
+                            type: string
+                        type: object
+                      repository:
+                        description: Repository is a URL link to the git repository
+                          containing the bundle. Repository is required and the URL
+                          should be parsable by a standard git tool.
+                        type: string
+                    required:
+                    - ref
+                    - repository
+                    type: object
+                  image:
+                    description: Image is the bundle image that backs the content
+                      of this bundle.
+                    properties:
+                      pullSecret:
+                        description: ImagePullSecretName contains the name of the
+                          image pull secret in the namespace that the provisioner
+                          is deployed.
+                        type: string
+                      ref:
+                        description: Ref contains the reference to a container image
+                          containing Bundle contents.
+                        type: string
+                    required:
+                    - ref
+                    type: object
+                  local:
+                    description: Local is a reference to a local object in the cluster.
+                    properties:
+                      configMap:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - configMap
+                    type: object
+                  type:
+                    description: Type defines the kind of Bundle content being sourced.
+                    type: string
+                  upload:
+                    description: Upload is a source that enables this Bundle's content
+                      to be uploaded via Rukpak's bundle upload service. This source
+                      type is primarily useful with bundle development workflows because
+                      it enables bundle developers to inject a local bundle directly
+                      into the cluster.
+                    type: object
+                required:
+                - type
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/rukpak/apis/crds/kustomization.yml
+++ b/config/rukpak/apis/crds/kustomization.yml
@@ -1,0 +1,10 @@
+resources:
+- core.rukpak.io_bundles.yaml
+- core.rukpak.io_bundledeployments.yaml
+patches:
+- path: patches/bundle_validation.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: bundles.core.rukpak.io

--- a/config/rukpak/apis/crds/patches/bundle_validation.yaml
+++ b/config/rukpak/apis/crds/patches/bundle_validation.yaml
@@ -1,0 +1,31 @@
+# limit bundle name length up to 40
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      maxLength: 40
+
+# Union source type
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/source/oneOf
+  value:
+  - required:
+    - git
+  - required:
+    - image
+  - required:
+    - local
+  - required:
+    - upload
+
+# Union git ref
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/source/properties/git/properties/ref/oneOf
+  value:
+  - required:
+    - branch
+  - required:
+    - commit
+  - required:
+    - tag

--- a/config/rukpak/apis/kustomization.yml
+++ b/config/rukpak/apis/kustomization.yml
@@ -1,0 +1,3 @@
+bases:
+- ./crds
+- ./webhooks

--- a/config/rukpak/apis/webhooks/kustomization.yml
+++ b/config/rukpak/apis/webhooks/kustomization.yml
@@ -1,0 +1,44 @@
+namespace: rukpak-system
+namePrefix: rukpak-
+
+resources:
+  - resources/namespace.yaml
+  - resources/serviceaccount.yaml
+  - resources/service.yaml
+  - resources/certificate.yaml
+  - resources/deployment.yaml
+  - resources/webhook.yaml
+
+configurations:
+- kustomizeconfig.yaml
+
+patchesStrategicMerge:
+- patches/cainjection.yaml
+
+vars:
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: webhook-certificate # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: webhook-certificate # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/rukpak/apis/webhooks/kustomizeconfig.yaml
+++ b/config/rukpak/apis/webhooks/kustomizeconfig.yaml
@@ -1,0 +1,28 @@
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name
+
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: metadata/annotations

--- a/config/rukpak/apis/webhooks/patches/cainjection.yaml
+++ b/config/rukpak/apis/webhooks/patches/cainjection.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/rukpak/apis/webhooks/resources/certificate.yaml
+++ b/config/rukpak/apis/webhooks/resources/certificate.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: webhook-certificate
+  namespace: system
+spec:
+  secretName: rukpak-webhook-certificate
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned

--- a/config/rukpak/apis/webhooks/resources/deployment.yaml
+++ b/config/rukpak/apis/webhooks/resources/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: system
+  name: webhooks
+  labels:
+    app: webhooks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhooks
+  template:
+    metadata:
+      labels:
+        app: webhooks
+    spec:
+      serviceAccountName: webhooks-admin
+      containers:
+        - name: webhooks
+          command: ["/webhooks"]
+          image: quay.io/operator-framework/rukpak:v0.8.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: rukpak-webhook-certificate

--- a/config/rukpak/apis/webhooks/resources/namespace.yaml
+++ b/config/rukpak/apis/webhooks/resources/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/config/rukpak/apis/webhooks/resources/service.yaml
+++ b/config/rukpak/apis/webhooks/resources/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: webhooks

--- a/config/rukpak/apis/webhooks/resources/serviceaccount.yaml
+++ b/config/rukpak/apis/webhooks/resources/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhooks-admin
+  namespace: system

--- a/config/rukpak/apis/webhooks/resources/webhook.yaml
+++ b/config/rukpak/apis/webhooks/resources/webhook.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-core-rukpak-io-v1alpha1-bundle
+  failurePolicy: Fail
+  name: vbundles.core.rukpak.io
+  rules:
+  - apiGroups:
+    - core.rukpak.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bundles
+  sideEffects: None

--- a/config/rukpak/core/kustomization.yaml
+++ b/config/rukpak/core/kustomization.yaml
@@ -1,0 +1,24 @@
+resources:
+  - resources/bundle_reader_client_clusterrole.yaml
+  - resources/bundle_uploader_client_clusterrole.yaml
+  - resources/rukpak_issuer.yaml
+  - resources/certificate.yaml
+  - resources/cluster_role.yaml
+  - resources/cluster_role_binding.yaml
+  - resources/deployment.yaml
+  - resources/service.yaml
+  - resources/serviceaccount.yaml
+
+vars:
+ - name: CORE_SERVICE_NAMESPACE # namespace of the service
+   objref:
+    kind: Service
+    version: v1
+    name: core
+   fieldref:
+    fieldpath: metadata.namespace
+ - name: CORE_SERVICE_NAME
+   objref:
+    kind: Service
+    version: v1
+    name: core

--- a/config/rukpak/core/resources/bundle_reader_client_clusterrole.yaml
+++ b/config/rukpak/core/resources/bundle_reader_client_clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bundle-reader
+rules:
+  - nonResourceURLs:
+      - /bundles/*
+    verbs:
+      - get

--- a/config/rukpak/core/resources/bundle_uploader_client_clusterrole.yaml
+++ b/config/rukpak/core/resources/bundle_uploader_client_clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bundle-uploader
+rules:
+  - nonResourceURLs:
+      - /bundles/*
+    verbs:
+      - put

--- a/config/rukpak/core/resources/certificate.yaml
+++ b/config/rukpak/core/resources/certificate.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: core
+  namespace: rukpak-system
+spec:
+  secretName: core-cert
+  dnsNames:
+    - localhost
+    - $(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc
+    - $(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: rukpak-ca-issuer

--- a/config/rukpak/core/resources/cluster_role.yaml
+++ b/config/rukpak/core/resources/cluster_role.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: core-admin
+rules:
+- nonResourceURLs:
+  - /bundles/*
+  verbs:
+  - get
+- nonResourceURLs:
+  - /uploads/*
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles/status
+  verbs:
+  - patch
+  - update

--- a/config/rukpak/core/resources/cluster_role_binding.yaml
+++ b/config/rukpak/core/resources/cluster_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: core-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: core-admin
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: core-admin
+    namespace: rukpak-system

--- a/config/rukpak/core/resources/deployment.yaml
+++ b/config/rukpak/core/resources/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: rukpak-system
+  name: core
+  labels:
+    app: core
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: core
+  template:
+    metadata:
+      labels:
+        app: core
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      serviceAccountName: core-admin
+      containers:
+        - name: kube-rbac-proxy
+          image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=10"
+            - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            - "--tls-cert-file=/etc/pki/tls/tls.crt"
+            - "--tls-private-key-file=/etc/pki/tls/tls.key"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+          volumeMounts:
+            - name: certs
+              mountPath: /etc/pki/tls
+        - name: manager
+          image: quay.io/operator-framework/rukpak:v0.8.0
+          imagePullPolicy: IfNotPresent
+          command: ["/core"]
+          args:
+            - "--unpack-image=quay.io/operator-framework/rukpak:v0.8.0"
+            - "--base-upload-manager-url=https://$(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc"
+            - "--provisioner-storage-dir=/var/cache/bundles"
+            - "--upload-storage-dir=/var/cache/uploads"
+            - "--http-bind-address=127.0.0.1:8080"
+            - "--http-external-address=https://$(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc"
+            - "--bundle-ca-file=/etc/pki/tls/ca.crt"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: bundle-cache
+              mountPath: /var/cache/bundles
+            - name: upload-cache
+              mountPath: /var/cache/uploads
+            - name: certs
+              mountPath: /etc/pki/tls
+      volumes:
+        - name: bundle-cache
+          emptyDir: {}
+        - name: upload-cache
+          emptyDir: {}
+        - name: certs
+          secret:
+            secretName: core-cert
+            optional: false

--- a/config/rukpak/core/resources/rukpak_issuer.yaml
+++ b/config/rukpak/core/resources/rukpak_issuer.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: rukpak-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: rukpak-ca
+  namespace: rukpak-system
+spec:
+  isCA: true
+  secretName: rukpak-ca
+  dnsNames:
+    - rukpak.io
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  privateKey:
+    rotationPolicy: Always
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: rukpak-selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: rukpak-ca-issuer
+  namespace: rukpak-system
+spec:
+  ca:
+    secretName: rukpak-ca

--- a/config/rukpak/core/resources/service.yaml
+++ b/config/rukpak/core/resources/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: rukpak-system
+  name: core
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app: core

--- a/config/rukpak/core/resources/serviceaccount.yaml
+++ b/config/rukpak/core/resources/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: core-admin
+  namespace: rukpak-system

--- a/config/rukpak/crdvalidator/00_namespace.yaml
+++ b/config/rukpak/crdvalidator/00_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crdvalidator-system

--- a/config/rukpak/crdvalidator/01_cluster_role.yaml
+++ b/config/rukpak/crdvalidator/01_cluster_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-validation-webhook
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["list"]

--- a/config/rukpak/crdvalidator/01_service_account.yaml
+++ b/config/rukpak/crdvalidator/01_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: crdvalidator-system
+  name: crd-validation-webhook

--- a/config/rukpak/crdvalidator/02_cluster_role_binding.yaml
+++ b/config/rukpak/crdvalidator/02_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-validation-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-validation-webhook
+subjects:
+- kind: ServiceAccount
+  name: crd-validation-webhook
+  namespace: crdvalidator-system

--- a/config/rukpak/crdvalidator/03_service.yaml
+++ b/config/rukpak/crdvalidator/03_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+spec:
+  ports:
+    - port: 9443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: crd-validation-webhook

--- a/config/rukpak/crdvalidator/04_webhook.yaml
+++ b/config/rukpak/crdvalidator/04_webhook.yaml
@@ -1,0 +1,45 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: crd-validation-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: crdvalidator-system/crd-validation-webhook-certificate
+webhooks:
+  - name: "webhook.crdvalidator.io"
+    rules:
+    - apiGroups: ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["customresourcedefinitions"]
+      scope: "*"
+    clientConfig:
+      service:
+        namespace: crdvalidator-system
+        name: crd-validation-webhook
+        path: /validate-crd
+        port: 9443
+    objectSelector:
+      matchLabels:
+        core.rukpak.io/owner-kind: BundleDeployment
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: crd-validation-webhook-certificate
+  namespace: crdvalidator-system
+spec:
+  secretName: crd-validation-webhook-certificate
+  dnsNames:
+    - crd-validation-webhook.crdvalidator-system.svc
+  issuerRef:
+    name: selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: crdvalidator-system
+spec:
+  selfSigned: {}

--- a/config/rukpak/crdvalidator/05_deployment.yaml
+++ b/config/rukpak/crdvalidator/05_deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+spec:
+  selector:
+    matchLabels:
+      app: crd-validation-webhook
+  template:
+    metadata:
+      labels:
+        app: crd-validation-webhook
+    spec:
+      serviceAccountName: crd-validation-webhook
+      containers:
+        - image: quay.io/operator-framework/rukpak:v0.8.0
+          imagePullPolicy: IfNotPresent
+          command: ["/crdvalidator"]
+          name: crd-validation-webhook
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/admission-webhook/tls"
+      volumes:
+        - name: tls
+          secret:
+            secretName: crd-validation-webhook-certificate

--- a/config/rukpak/crdvalidator/kustomization.yml
+++ b/config/rukpak/crdvalidator/kustomization.yml
@@ -1,0 +1,8 @@
+resources:
+  - 00_namespace.yaml
+  - 01_cluster_role.yaml
+  - 01_service_account.yaml
+  - 02_cluster_role_binding.yaml
+  - 03_service.yaml
+  - 04_webhook.yaml
+  - 05_deployment.yaml

--- a/config/rukpak/kustomization.yaml
+++ b/config/rukpak/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ./apis
+  - ./core
+  - ./crdvalidator

--- a/manifests/0000_50_cluster-platform-operator-manager_00-rukpak.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-rukpak.yaml
@@ -1,0 +1,1035 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crdvalidator-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rukpak-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: bundledeployments.core.rukpak.io
+spec:
+  group: core.rukpak.io
+  names:
+    kind: BundleDeployment
+    listKind: BundleDeploymentList
+    plural: bundledeployments
+    shortNames:
+    - bd
+    - bds
+    singular: bundledeployment
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.activeBundle
+      name: Active Bundle
+      type: string
+    - jsonPath: .status.conditions[?(.type=="Installed")].reason
+      name: Install State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BundleDeployment is the Schema for the bundledeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BundleDeploymentSpec defines the desired state of BundleDeployment
+            properties:
+              provisionerClassName:
+                description: ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
+                type: string
+              template:
+                description: Template describes the generated Bundle that this deployment will manage.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the Bundle. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      provisionerClassName:
+                        description: ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
+                        type: string
+                      source:
+                        description: Source defines the configuration for the underlying Bundle content.
+                        properties:
+                          git:
+                            description: Git is the git repository that backs the content of this Bundle.
+                            properties:
+                              auth:
+                                description: Auth configures the authorization method if necessary.
+                                properties:
+                                  insecureSkipVerify:
+                                    description: InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name. If InsecureSkipVerify is true, the clone operation will accept any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to machine-in-the-middle attacks unless custom verification is used. This should be used only for testing.
+                                    type: boolean
+                                  secret:
+                                    description: Secret contains reference to the secret that has authorization information and is in the namespace that the provisioner is deployed. The secret is expected to contain `data.username` and `data.password` for the username and password, respectively for http(s) scheme. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret The secret is expected to contain `data.ssh-privatekey` and `data.ssh-knownhosts` for the ssh privatekey and the host entry in the known_hosts file respectively for ssh authorization. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                    type: object
+                                type: object
+                              directory:
+                                description: Directory refers to the location of the bundle within the git repository. Directory is optional and if not set defaults to ./manifests.
+                                type: string
+                              ref:
+                                description: Ref configures the git source to clone a specific branch, tag, or commit from the specified repo. Ref is required, and exactly one field within Ref is required. Setting more than one field or zero fields will result in an error.
+                                properties:
+                                  branch:
+                                    description: Branch refers to the branch to checkout from the repository. The Branch should contain the bundle manifests in the specified directory.
+                                    type: string
+                                  commit:
+                                    description: Commit refers to the commit to checkout from the repository. The Commit should contain the bundle manifests in the specified directory.
+                                    type: string
+                                  tag:
+                                    description: Tag refers to the tag to checkout from the repository. The Tag should contain the bundle manifests in the specified directory.
+                                    type: string
+                                type: object
+                              repository:
+                                description: Repository is a URL link to the git repository containing the bundle. Repository is required and the URL should be parsable by a standard git tool.
+                                type: string
+                            required:
+                            - ref
+                            - repository
+                            type: object
+                          image:
+                            description: Image is the bundle image that backs the content of this bundle.
+                            properties:
+                              pullSecret:
+                                description: ImagePullSecretName contains the name of the image pull secret in the namespace that the provisioner is deployed.
+                                type: string
+                              ref:
+                                description: Ref contains the reference to a container image containing Bundle contents.
+                                type: string
+                            required:
+                            - ref
+                            type: object
+                          local:
+                            description: Local is a reference to a local object in the cluster.
+                            properties:
+                              configMap:
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                required:
+                                - name
+                                - namespace
+                                type: object
+                            required:
+                            - configMap
+                            type: object
+                          type:
+                            description: Type defines the kind of Bundle content being sourced.
+                            type: string
+                          upload:
+                            description: Upload is a source that enables this Bundle's content to be uploaded via Rukpak's bundle upload service. This source type is primarily useful with bundle development workflows because it enables bundle developers to inject a local bundle directly into the cluster.
+                            type: object
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - provisionerClassName
+                    - source
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - provisionerClassName
+            - template
+            type: object
+          status:
+            description: BundleDeploymentStatus defines the observed state of BundleDeployment
+            properties:
+              activeBundle:
+                type: string
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: bundles.core.rukpak.io
+spec:
+  group: core.rukpak.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.source.type
+      name: Type
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.resolvedSource
+      name: Resolved Source
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Bundle is the Schema for the bundles API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                maxLength: 40
+                type: string
+            type: object
+          spec:
+            description: BundleSpec defines the desired state of Bundle
+            properties:
+              provisionerClassName:
+                description: ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
+                type: string
+              source:
+                description: Source defines the configuration for the underlying Bundle content.
+                oneOf:
+                - required:
+                  - git
+                - required:
+                  - image
+                - required:
+                  - local
+                - required:
+                  - upload
+                properties:
+                  git:
+                    description: Git is the git repository that backs the content of this Bundle.
+                    properties:
+                      auth:
+                        description: Auth configures the authorization method if necessary.
+                        properties:
+                          insecureSkipVerify:
+                            description: InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name. If InsecureSkipVerify is true, the clone operation will accept any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to machine-in-the-middle attacks unless custom verification is used. This should be used only for testing.
+                            type: boolean
+                          secret:
+                            description: Secret contains reference to the secret that has authorization information and is in the namespace that the provisioner is deployed. The secret is expected to contain `data.username` and `data.password` for the username and password, respectively for http(s) scheme. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret The secret is expected to contain `data.ssh-privatekey` and `data.ssh-knownhosts` for the ssh privatekey and the host entry in the known_hosts file respectively for ssh authorization. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                        type: object
+                      directory:
+                        description: Directory refers to the location of the bundle within the git repository. Directory is optional and if not set defaults to ./manifests.
+                        type: string
+                      ref:
+                        description: Ref configures the git source to clone a specific branch, tag, or commit from the specified repo. Ref is required, and exactly one field within Ref is required. Setting more than one field or zero fields will result in an error.
+                        oneOf:
+                        - required:
+                          - branch
+                        - required:
+                          - commit
+                        - required:
+                          - tag
+                        properties:
+                          branch:
+                            description: Branch refers to the branch to checkout from the repository. The Branch should contain the bundle manifests in the specified directory.
+                            type: string
+                          commit:
+                            description: Commit refers to the commit to checkout from the repository. The Commit should contain the bundle manifests in the specified directory.
+                            type: string
+                          tag:
+                            description: Tag refers to the tag to checkout from the repository. The Tag should contain the bundle manifests in the specified directory.
+                            type: string
+                        type: object
+                      repository:
+                        description: Repository is a URL link to the git repository containing the bundle. Repository is required and the URL should be parsable by a standard git tool.
+                        type: string
+                    required:
+                    - ref
+                    - repository
+                    type: object
+                  image:
+                    description: Image is the bundle image that backs the content of this bundle.
+                    properties:
+                      pullSecret:
+                        description: ImagePullSecretName contains the name of the image pull secret in the namespace that the provisioner is deployed.
+                        type: string
+                      ref:
+                        description: Ref contains the reference to a container image containing Bundle contents.
+                        type: string
+                    required:
+                    - ref
+                    type: object
+                  local:
+                    description: Local is a reference to a local object in the cluster.
+                    properties:
+                      configMap:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - configMap
+                    type: object
+                  type:
+                    description: Type defines the kind of Bundle content being sourced.
+                    type: string
+                  upload:
+                    description: Upload is a source that enables this Bundle's content to be uploaded via Rukpak's bundle upload service. This source type is primarily useful with bundle development workflows because it enables bundle developers to inject a local bundle directly into the cluster.
+                    type: object
+                required:
+                - type
+                type: object
+            required:
+            - provisionerClassName
+            - source
+            type: object
+          status:
+            description: BundleStatus defines the observed state of Bundle
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              contentURL:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+              resolvedSource:
+                properties:
+                  git:
+                    description: Git is the git repository that backs the content of this Bundle.
+                    properties:
+                      auth:
+                        description: Auth configures the authorization method if necessary.
+                        properties:
+                          insecureSkipVerify:
+                            description: InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name. If InsecureSkipVerify is true, the clone operation will accept any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to machine-in-the-middle attacks unless custom verification is used. This should be used only for testing.
+                            type: boolean
+                          secret:
+                            description: Secret contains reference to the secret that has authorization information and is in the namespace that the provisioner is deployed. The secret is expected to contain `data.username` and `data.password` for the username and password, respectively for http(s) scheme. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret The secret is expected to contain `data.ssh-privatekey` and `data.ssh-knownhosts` for the ssh privatekey and the host entry in the known_hosts file respectively for ssh authorization. Refer to https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                        type: object
+                      directory:
+                        description: Directory refers to the location of the bundle within the git repository. Directory is optional and if not set defaults to ./manifests.
+                        type: string
+                      ref:
+                        description: Ref configures the git source to clone a specific branch, tag, or commit from the specified repo. Ref is required, and exactly one field within Ref is required. Setting more than one field or zero fields will result in an error.
+                        properties:
+                          branch:
+                            description: Branch refers to the branch to checkout from the repository. The Branch should contain the bundle manifests in the specified directory.
+                            type: string
+                          commit:
+                            description: Commit refers to the commit to checkout from the repository. The Commit should contain the bundle manifests in the specified directory.
+                            type: string
+                          tag:
+                            description: Tag refers to the tag to checkout from the repository. The Tag should contain the bundle manifests in the specified directory.
+                            type: string
+                        type: object
+                      repository:
+                        description: Repository is a URL link to the git repository containing the bundle. Repository is required and the URL should be parsable by a standard git tool.
+                        type: string
+                    required:
+                    - ref
+                    - repository
+                    type: object
+                  image:
+                    description: Image is the bundle image that backs the content of this bundle.
+                    properties:
+                      pullSecret:
+                        description: ImagePullSecretName contains the name of the image pull secret in the namespace that the provisioner is deployed.
+                        type: string
+                      ref:
+                        description: Ref contains the reference to a container image containing Bundle contents.
+                        type: string
+                    required:
+                    - ref
+                    type: object
+                  local:
+                    description: Local is a reference to a local object in the cluster.
+                    properties:
+                      configMap:
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - configMap
+                    type: object
+                  type:
+                    description: Type defines the kind of Bundle content being sourced.
+                    type: string
+                  upload:
+                    description: Upload is a source that enables this Bundle's content to be uploaded via Rukpak's bundle upload service. This source type is primarily useful with bundle development workflows because it enables bundle developers to inject a local bundle directly into the cluster.
+                    type: object
+                required:
+                - type
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: core-admin
+  namespace: rukpak-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rukpak-webhooks-admin
+  namespace: rukpak-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bundle-reader
+rules:
+- nonResourceURLs:
+  - /bundles/*
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bundle-uploader
+rules:
+- nonResourceURLs:
+  - /bundles/*
+  verbs:
+  - put
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: core-admin
+rules:
+- nonResourceURLs:
+  - /bundles/*
+  verbs:
+  - get
+- nonResourceURLs:
+  - /uploads/*
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles/status
+  verbs:
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-validation-webhook
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: core-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: core-admin
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: core-admin
+  namespace: rukpak-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-validation-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-validation-webhook
+subjects:
+- kind: ServiceAccount
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+spec:
+  ports:
+  - port: 9443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: crd-validation-webhook
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: core
+  namespace: rukpak-system
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: core
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rukpak-webhook-service
+  namespace: rukpak-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: webhooks
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+spec:
+  selector:
+    matchLabels:
+      app: crd-validation-webhook
+  template:
+    metadata:
+      labels:
+        app: crd-validation-webhook
+    spec:
+      containers:
+      - command:
+        - /crdvalidator
+        image: quay.io/operator-framework/rukpak:v0.8.0
+        imagePullPolicy: IfNotPresent
+        name: crd-validation-webhook
+        volumeMounts:
+        - mountPath: /etc/admission-webhook/tls
+          name: tls
+      serviceAccountName: crd-validation-webhook
+      volumes:
+      - name: tls
+        secret:
+          secretName: crd-validation-webhook-certificate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: core
+  name: core
+  namespace: rukpak-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: core
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app: core
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        - --client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - --tls-cert-file=/etc/pki/tls/tls.crt
+        - --tls-private-key-file=/etc/pki/tls/tls.key
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/pki/tls
+          name: certs
+      - args:
+        - --unpack-image=quay.io/operator-framework/rukpak:v0.8.0
+        - --base-upload-manager-url=https://core.rukpak-system.svc
+        - --provisioner-storage-dir=/var/cache/bundles
+        - --upload-storage-dir=/var/cache/uploads
+        - --http-bind-address=127.0.0.1:8080
+        - --http-external-address=https://core.rukpak-system.svc
+        - --bundle-ca-file=/etc/pki/tls/ca.crt
+        command:
+        - /core
+        image: quay.io/operator-framework/rukpak:v0.8.0
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - mountPath: /var/cache/bundles
+          name: bundle-cache
+        - mountPath: /var/cache/uploads
+          name: upload-cache
+        - mountPath: /etc/pki/tls
+          name: certs
+      serviceAccountName: core-admin
+      volumes:
+      - emptyDir: {}
+        name: bundle-cache
+      - emptyDir: {}
+        name: upload-cache
+      - name: certs
+        secret:
+          optional: false
+          secretName: core-cert
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: webhooks
+  name: rukpak-webhooks
+  namespace: rukpak-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhooks
+  template:
+    metadata:
+      labels:
+        app: webhooks
+    spec:
+      containers:
+      - command:
+        - /webhooks
+        image: quay.io/operator-framework/rukpak:v0.8.0
+        imagePullPolicy: IfNotPresent
+        name: webhooks
+        ports:
+        - containerPort: 8080
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: rukpak-webhooks-admin
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: rukpak-webhook-certificate
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: crd-validation-webhook-certificate
+  namespace: crdvalidator-system
+spec:
+  dnsNames:
+  - crd-validation-webhook.crdvalidator-system.svc
+  issuerRef:
+    name: selfsigned
+  secretName: crd-validation-webhook-certificate
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: core
+  namespace: rukpak-system
+spec:
+  dnsNames:
+  - localhost
+  - core.rukpak-system.svc
+  - core.rukpak-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: rukpak-ca-issuer
+  secretName: core-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: rukpak-ca
+  namespace: rukpak-system
+spec:
+  dnsNames:
+  - rukpak.io
+  duration: 2160h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: rukpak-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    rotationPolicy: Always
+    size: 256
+  renewBefore: 360h
+  secretName: rukpak-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: rukpak-webhook-certificate
+  namespace: rukpak-system
+spec:
+  dnsNames:
+  - rukpak-webhook-service.rukpak-system.svc
+  - rukpak-webhook-service.rukpak-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: rukpak-selfsigned
+  secretName: rukpak-webhook-certificate
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: rukpak-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: crdvalidator-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: rukpak-ca-issuer
+  namespace: rukpak-system
+spec:
+  ca:
+    secretName: rukpak-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: rukpak-selfsigned
+  namespace: rukpak-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: crdvalidator-system/crd-validation-webhook-certificate
+  name: crd-validation-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: crd-validation-webhook
+      namespace: crdvalidator-system
+      path: /validate-crd
+      port: 9443
+  name: webhook.crdvalidator.io
+  objectSelector:
+    matchLabels:
+      core.rukpak.io/owner-kind: BundleDeployment
+  rules:
+  - apiGroups:
+    - apiextensions.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - customresourcedefinitions
+    scope: '*'
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: rukpak-system/rukpak-webhook-certificate
+  name: rukpak-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: rukpak-webhook-service
+      namespace: rukpak-system
+      path: /validate-core-rukpak-io-v1alpha1-bundle
+  failurePolicy: Fail
+  name: vbundles.core.rukpak.io
+  rules:
+  - apiGroups:
+    - core.rukpak.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bundles
+  sideEffects: None


### PR DESCRIPTION
## Summary
This PR adds the Rukpak manifests into the root of Platform Operators so that, in this interim period between it being added into the core payload, it can come shipped with Rukpak as needed. 

There are a lot of changes here but most of them are directly ported from downstream Rukpak. The main file I would keep an eye on is the Makefile as well the repo general structure.

> *Note*: These manifests still require that cert-manager be installed in order to run. We should think if we want cert-manager to be a dependency here as well and introduce it into its installation temporarily or avoid it all together.

## Not handled here, but should consider
1. Automatically syncing the manifests between [downstream rukpak](https://github.com/openshift/operator-framework-rukpak) and here.
2. Adding automation to increment the version of the Rukpak image used.
3. Removal of cert-manager as a dependency.