### PR TITLE
(psa) label namespace PSA:`restricted`, and make workload compliant

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,9 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    openshift.io/scc: "anyuid"
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
   name: system
 ---
 apiVersion: apps/v1
@@ -26,6 +29,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -36,6 +41,8 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+              drop: [ "ALL" ]
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/rukpak/apis/webhooks/resources/deployment.yaml
+++ b/config/rukpak/apis/webhooks/resources/deployment.yaml
@@ -9,6 +9,10 @@ spec:
   strategy:
     rollingUpdate:
       maxUnavailable: 25%
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   selector:
     matchLabels:
       app: webhooks
@@ -27,6 +31,10 @@ spec:
       serviceAccountName: webhooks-admin
       containers:
         - name: webhooks
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           command: ["/webhooks"]
           image: quay.io/operator-framework/rukpak:v0.8.0
           imagePullPolicy: IfNotPresent

--- a/config/rukpak/core/resources/deployment.yaml
+++ b/config/rukpak/core/resources/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     app: core
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   replicas: 1
   selector:
     matchLabels:
@@ -19,6 +23,10 @@ spec:
       serviceAccountName: core-admin
       containers:
         - name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/brancz/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
@@ -36,6 +44,10 @@ spec:
             - name: certs
               mountPath: /etc/pki/tls
         - name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/operator-framework/rukpak:v0.8.0
           imagePullPolicy: IfNotPresent
           command: ["/core"]

--- a/manifests/0000_60_cluster-platform-operator-manager_00-namespace.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_00-namespace.yaml
@@ -5,4 +5,7 @@ metadata:
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager
+    openshift.io/scc: anyuid
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.24
   name: openshift-platform-operators

--- a/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: openshift-platform-operators
 spec:
   replicas: 1
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   selector:
     matchLabels:
       app: core
@@ -35,6 +39,11 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /etc/pki/tls
           name: certs
@@ -53,6 +62,11 @@ spec:
         name: manager
         ports:
         - containerPort: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/cache/bundles
           name: bundle-cache

--- a/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: openshift-platform-operators
 spec:
   replicas: 2
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   selector:
     matchLabels:
       app: webhooks
@@ -40,6 +44,11 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/manifests/0000_60_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_06-deployment.yaml
@@ -62,7 +62,12 @@ spec:
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: platform-operators-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This PR applies the `restricted` security level [defined by the Pod Security
Admission Controller](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/). It also modifies
the deployments to add the required securityContext for the pods deployed to be
admitted at the `restricted` level.