### PR TITLE
Designate Platform Operators as Tech Preview

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,6 +12,10 @@ namePrefix: platform-operators-
 #commonLabels:
 #  someName: someValue
 
+# Annotations to add to all resources.
+commonAnnotations:
+  release.openshift.io/feature-gate: TechPreviewNoUpgrade
+
 bases:
 - ../crd
 - ../rbac

--- a/manifests/0000_60_cluster-platform-operator-manager_00-namespace.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_00-namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager
   name: openshift-platform-operators

--- a/manifests/0000_60_cluster-platform-operator-manager_00-platformoperator.crd.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_00-platformoperator.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platformoperators.platform.openshift.io
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: bundledeployments.core.rukpak.io
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_00-rukpak-bundles.crd.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_00-rukpak-bundles.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: bundles.core.rukpak.io
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-ca.certificate.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-ca.certificate.yaml
@@ -1,6 +1,8 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-ca
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-ca.issuer.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-ca.issuer.yaml
@@ -1,6 +1,8 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-ca-issuer
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-core-admin.sa.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-core-admin.sa.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core-admin
   namespace: openshift-platform-operators

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-core.certificate.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-core.certificate.yaml
@@ -1,6 +1,8 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-selfsigned.issuer.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-selfsigned.issuer.yaml
@@ -1,6 +1,8 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-selfsigned-issuer
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-webhook-selfsigned.issuer.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-webhook-selfsigned.issuer.yaml
@@ -1,6 +1,8 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-selfsigned
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-webhook.certificate.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-webhook.certificate.yaml
@@ -1,6 +1,8 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-webhook-certificate
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-webhooks-admin.sa.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-rukpak-webhooks-admin.sa.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-webhooks-admin
   namespace: openshift-platform-operators

--- a/manifests/0000_60_cluster-platform-operator-manager_01-serviceaccount.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_01-serviceaccount.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-controller-manager
   namespace: openshift-platform-operators

--- a/manifests/0000_60_cluster-platform-operator-manager_02-metricsservice.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_02-metricsservice.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager
   name: platform-operators-controller-manager-metrics-service

--- a/manifests/0000_60_cluster-platform-operator-manager_02-rukpak-core.service.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_02-rukpak-core.service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_02-rukpak-webhook.service.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_02-rukpak-webhook.service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-webhook-service
   namespace: openshift-platform-operators
 spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_03_rbac.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_03_rbac.yaml
@@ -1,6 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platform-operators-manager-role
 rules:
@@ -66,6 +68,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-metrics-reader
 rules:
 - nonResourceURLs:
@@ -76,6 +80,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-proxy-role
 rules:
 - apiGroups:
@@ -94,6 +100,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -107,6 +115,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -120,6 +130,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-leader-election-role
   namespace: openshift-platform-operators
 rules:
@@ -158,6 +170,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-leader-election-rolebinding
   namespace: openshift-platform-operators
 roleRef:
@@ -172,6 +186,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-bundle-reader
 rules:
 - nonResourceURLs:
@@ -182,6 +198,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-bundle-uploader
 rules:
 - nonResourceURLs:
@@ -192,6 +210,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platform-operators-rukpak-core-admin
 rules:
@@ -282,6 +302,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     app: core
   name: platform-operators-rukpak-core
@@ -14,6 +16,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        release.openshift.io/feature-gate: TechPreviewNoUpgrade
       labels:
         app: core
     spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     app: webhooks
   name: platform-operators-rukpak-webhooks
@@ -12,6 +14,8 @@ spec:
       app: webhooks
   template:
     metadata:
+      annotations:
+        release.openshift.io/feature-gate: TechPreviewNoUpgrade
       labels:
         app: webhooks
     spec:

--- a/manifests/0000_60_cluster-platform-operator-manager_05-rukpak.validating-webhook-configuration.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_05-rukpak.validating-webhook-configuration.yaml
@@ -3,6 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: openshift-platform-operators/platform-operators-rukpak-webhook-certificate
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/manifests/0000_60_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_06-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager
   name: platform-operators-controller-manager
@@ -14,6 +16,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        release.openshift.io/feature-gate: TechPreviewNoUpgrade
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
The platform operators project is being released as a Tech Preview
feature within OpenShift. A project managed by CVO is designated as a
Tech Preview feature by setting the "release.openshift.io/feature-gate"
annotation to "TechPreviewNoUpgrade". CVO will not apply any resources
with this annotation and key to the cluster unless the cluster has
Tech Preview features enabled.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>