### PR TITLE
Introduce Highly Available Webhook Deployments

### DIFF
--- a/config/rukpak/apis/webhooks/resources/deployment.yaml
+++ b/config/rukpak/apis/webhooks/resources/deployment.yaml
@@ -5,7 +5,10 @@ metadata:
   labels:
     app: webhooks
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 25%
   selector:
     matchLabels:
       app: webhooks
@@ -14,6 +17,13 @@ spec:
       labels:
         app: webhooks
     spec:
+      affinity:
+        podAntiAffinity: 
+          requiredDuringSchedulingIgnoredDuringExecution: 
+          - labelSelector:
+              matchLabels:
+                app: webhooks
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: webhooks-admin
       containers:
         - name: webhooks

--- a/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
+++ b/manifests/0000_60_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
@@ -6,15 +6,25 @@ metadata:
   name: platform-operators-rukpak-webhooks
   namespace: openshift-platform-operators
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: webhooks
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 25%
   template:
     metadata:
       labels:
         app: webhooks
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: webhooks
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /webhooks


### PR DESCRIPTION
This commit introduces a number of changes aimed at ensuring that the
webhook deployments introduced by the platform operators project remain
highly available during deployment and upgrades.

Signed-off-by: Alexander Greene <greene.al1991@gmail.com>