### PR TITLE
config/rukpak: Add the HA webhook configurations to a patch file

### DIFF
--- a/config/rukpak/apis/webhooks/kustomization.yml
+++ b/config/rukpak/apis/webhooks/kustomization.yml
@@ -10,6 +10,7 @@ configurations:
 
 patchesStrategicMerge:
 - patches/cainjection.yaml
+- patches/high-availability.yaml
 
 vars:
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR

--- a/config/rukpak/apis/webhooks/patches/high-availability.yaml
+++ b/config/rukpak/apis/webhooks/patches/high-availability.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhooks
+spec:
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 25%
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: webhooks
+            topologyKey: kubernetes.io/hostname

--- a/config/rukpak/apis/webhooks/resources/deployment.yaml
+++ b/config/rukpak/apis/webhooks/resources/deployment.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     app: webhooks
 spec:
-  replicas: 2
-  strategy:
-    rollingUpdate:
-      maxUnavailable: 25%
   selector:
     matchLabels:
       app: webhooks
@@ -17,13 +13,6 @@ spec:
       labels:
         app: webhooks
     spec:
-      affinity:
-        podAntiAffinity: 
-          requiredDuringSchedulingIgnoredDuringExecution: 
-          - labelSelector:
-              matchLabels:
-                app: webhooks
-            topologyKey: kubernetes.io/hostname
       serviceAccountName: webhooks-admin
       containers:
         - name: webhooks


### PR DESCRIPTION
Moves the HA webhook deployment configurations to a patch file to make it easier to toggle this configuration on/off for local crc development usage.

Signed-off-by: timflannagan <timflannagan@gmail.com>