### PR TITLE
Dockerfile: Use COPY instead of ADD for copying the manifests directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make build
 
 FROM registry.ci.openshift.org/ocp/4.12:base
 
-ADD manifests/ /manifests
+COPY manifests /manifests
 # LABEL io.openshift.release.operator=true
 
 COPY --from=builder /build/bin/manager /bin


### PR DESCRIPTION
Fails the prodsec static tooling analysis.