### PR TITLE
config,manifests: Add the required self-managed-high-availability cluster profile annotation

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,6 +15,7 @@ namePrefix: platform-operators-
 # Annotations to add to all resources.
 commonAnnotations:
   release.openshift.io/feature-gate: TechPreviewNoUpgrade
+  include.release.openshift.io/self-managed-high-availability: "true"
 
 bases:
 - ../rbac

--- a/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager

--- a/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: bundledeployments.core.rukpak.io

--- a/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundles.crd.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundles.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: bundles.core.rukpak.io

--- a/manifests/0000_50_cluster-platform-operator-manager_01-core-ca.cm.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-core-ca.cm.yaml
@@ -3,6 +3,7 @@ data: {}
 kind: ConfigMap
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   name: platform-operators-rukpak-core-tls

--- a/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-core-admin.sa.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-core-admin.sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core-admin
   namespace: openshift-platform-operators

--- a/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-webhooks-admin.sa.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-webhooks-admin.sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-webhooks-admin
   namespace: openshift-platform-operators

--- a/manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-controller-manager
   namespace: openshift-platform-operators

--- a/manifests/0000_50_cluster-platform-operator-manager_01-webhook-ca.cm.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-webhook-ca.cm.yaml
@@ -3,6 +3,7 @@ data: {}
 kind: ConfigMap
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   name: platform-operators-rukpak-webhook-tls

--- a/manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager

--- a/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-core.service.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-core.service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
     service.beta.openshift.io/serving-cert-secret-name: platform-operators-rukpak-core-tls
   name: platform-operators-rukpak-core

--- a/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-webhook.service.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-webhook.service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
     service.beta.openshift.io/serving-cert-secret-name: platform-operators-rukpak-webhook-tls
   name: platform-operators-rukpak-webhook-service

--- a/manifests/0000_50_cluster-platform-operator-manager_03_rbac.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_03_rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platform-operators-manager-role
@@ -69,6 +70,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-metrics-reader
 rules:
@@ -81,6 +83,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-proxy-role
 rules:
@@ -101,6 +104,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-manager-rolebinding
 roleRef:
@@ -116,6 +120,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-proxy-rolebinding
 roleRef:
@@ -131,6 +136,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-leader-election-role
   namespace: openshift-platform-operators
@@ -171,6 +177,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-leader-election-rolebinding
   namespace: openshift-platform-operators
@@ -187,6 +194,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-bundle-reader
 rules:
@@ -199,6 +207,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-bundle-uploader
 rules:
@@ -211,6 +220,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platform-operators-rukpak-core-admin
@@ -303,6 +313,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core-admin
 roleRef:

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     app: core
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        include.release.openshift.io/self-managed-high-availability: "true"
         kubectl.kubernetes.io/default-container: manager
         release.openshift.io/feature-gate: TechPreviewNoUpgrade
       labels:

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     app: webhooks
@@ -18,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        include.release.openshift.io/self-managed-high-availability: "true"
         release.openshift.io/feature-gate: TechPreviewNoUpgrade
       labels:
         app: webhooks

--- a/manifests/0000_50_cluster-platform-operator-manager_05-rukpak.validating-webhook-configuration.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_05-rukpak.validating-webhook-configuration.yaml
@@ -2,6 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   name: platform-operators-rukpak-validating-webhook-configuration

--- a/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
   labels:
     control-plane: controller-manager
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        include.release.openshift.io/self-managed-high-availability: "true"
         kubectl.kubernetes.io/default-container: manager
         release.openshift.io/feature-gate: TechPreviewNoUpgrade
       labels:


### PR DESCRIPTION
Splitting this out from #23. Updates the manifests and adds the required self-managed-high-availability cluster profile annotation. This is a pre-requisite to introducing the CPOM/rukpak components to the payload.

Signed-off-by: timflannagan <timflannagan@gmail.com>