### PR TITLE
config,manifests: Add PSA configuration for the CPOM deployment

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,10 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -38,6 +40,8 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
@@ -34,6 +34,11 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
@@ -64,7 +69,12 @@ spec:
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: platform-operators-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Follow-up to #28 which added the requisite PSA configuration for the rukpak component. This adds that same configuration for the CPOM component.

Signed-off-by: timflannagan <timflannagan@gmail.com>