### PR TITLE
Makefile,manifests: Add hack for injecting the self managed HA cluster cluster

### DIFF
--- a/manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     release.openshift.io/feature-gate: TechPreviewNoUpgrade
     api-approved.openshift.io: https://github.com/openshift/api/pull/1234
+    include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
   name: platformoperators.platform.openshift.io
 spec:


### PR DESCRIPTION
Update the PlatformOperator CRD YAML manifests housed in o/api, and inject the required self-managed HA cluster profile annotation. This is a short term hack in order to unblock payload introduction.

Signed-off-by: timflannagan <timflannagan@gmail.com>