### PR TITLE
config,manifests: Ensure the CPOM and rukpak components use the same kube-rbac-proxy image

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,6 +17,11 @@ commonAnnotations:
   release.openshift.io/feature-gate: TechPreviewNoUpgrade
   include.release.openshift.io/self-managed-high-availability: "true"
 
+images:
+- name: quay.io/brancz/kube-rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.8.0
+
 bases:
 - ../rbac
 - ../manager

--- a/config/rukpak/core/kustomization.yaml
+++ b/config/rukpak/core/kustomization.yaml
@@ -8,6 +8,11 @@ resources:
   - resources/serviceaccount.yaml
   - resources/core_ca_configmap.yaml
 
+images:
+- name: kube-rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.8.0
+
 vars:
  - name: CORE_SERVICE_NAMESPACE # namespace of the service
    objref:

--- a/config/rukpak/kustomization.yaml
+++ b/config/rukpak/kustomization.yaml
@@ -2,3 +2,7 @@ namePrefix: rukpak-
 bases:
   - ./apis
   - ./core
+images:
+- name: quay.io/brancz/kube-rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.8.0

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - --tls-cert-file=/etc/pki/tls/tls.crt
         - --tls-private-key-file=/etc/pki/tls/tls.key
         - --upstream-ca-file=/etc/configmaps/operator-cert-ca-bundle/service-ca.crt
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Moving this out of the WIP #23 PR.

Signed-off-by: timflannagan <timflannagan@gmail.com>