### PR TITLE
Makefile: Add support for focusing on a specific test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,9 @@ unit: generate envtest ## Run unit tests.
 e2e: deploy test-e2e
 
 .PHONY: test-e2e
+FOCUS := $(if $(TEST),-v -focus "$(TEST)")
 test-e2e: ginkgo ## Run e2e tests
-	$(GINKGO) -trace -progress test/e2e
+	$(GINKGO) -trace -progress $(FOCUS) test/e2e
 
 .PHONY: verify
 verify: tidy manifests


### PR DESCRIPTION
Adds support for focusing on a single e2e test at a time. Mirrors the setup in the major upstream OLM repositories. Example usage: `make test-e2e TEST="a failing PO has been encountered"`.

Signed-off-by: timflannagan <timflannagan@gmail.com>