### PR TITLE
hack,Makefile: Enable tech preview features after cluster creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
+deploy: export KUBECTL=oc
+deploy:
+	$(ROOT_DIR)/hack/apply-feature-gate.sh
+
 .PHONY: tidy
 tidy:
 	go mod tidy

--- a/hack/apply-feature-gate.sh
+++ b/hack/apply-feature-gate.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+set -e
+
+export ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp}
+export PO_NAMESPACE="openshift-platform-operators"
+
+KUBECTL=${KUBECTL:=kubectl}
+
+function cleanup() {
+    set +e +o pipefail
+    exit_status=$?
+
+    echo "Performing cleanup"
+
+    echo "Stopping background jobs"
+    # kill any background jobs
+    pids=$(jobs -pr)
+    local pids
+    [ -n "$pids" ] && kill -9 "$pids"
+    # Wait for any jobs
+    wait 2>/dev/null
+
+    echo "Exiting $0"
+    exit "$exit_status"
+}
+
+trap cleanup SIGINT
+
+function applyFeatureGate() {
+  echo "$(date -u --rfc-3339=seconds) - Apply TechPreviewNoUpgrade FeatureGate configuration"
+
+cat <<EOF | ${KUBECTL} apply -f -
+---
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade
+EOF
+}
+
+function waitForClusterOperatorsRollout() {
+  echo "$(date -u --rfc-3339=seconds) - Wait for the operator to go available..."
+  waitFor 10m ${KUBECTL} wait --all --for=condition=Available=True clusteroperators.config.openshift.io
+
+  echo "$(date -u --rfc-3339=seconds) - Waits for operators to finish rolling out..."
+  waitFor 30m ${KUBECTL} wait --all --for=condition=Progressing=False clusteroperators.config.openshift.io
+}
+
+function waitForRunningPod() {
+  local REGEXP="${1}"
+  local MSG="${1}"
+
+  while [ "$(${KUBECTL} get pods -n ${PO_NAMESPACE} -o name | grep -c "${REGEXP}")" == 0 ]; do
+    echo "$(date -u --rfc-3339=seconds) - ${MSG}"
+    sleep 5
+  done
+}
+export -f waitForRunningPod
+
+function ClusterPlatformOperatorPodsCreated() {
+  waitForRunningPod "platform-operators-rukpak-core" "Waiting for rukpak core creation"
+  waitForRunningPod "platform-operators-rukpak-webhooks" "Waiting for rukpak webhooks creation"
+}
+export -f ClusterPlatformOperatorPodsCreated
+
+function waitForClusterPlatformOperatorPodsReadiness() {
+  echo "$(date -u --rfc-3339=seconds) - Wait for PO operands to be ready"
+  waitFor 10m ${KUBECTL} wait --all -n "${PO_NAMESPACE}" --for=condition=ready pods
+}
+
+function waitFor() {
+  local TIMEOUT="${1}"
+  local CMD="${*:2}"
+
+  ret=0
+  timeout "${TIMEOUT}" bash -c "execute ${CMD}" || ret="$?"
+
+  # Command timed out
+  if [[ ret -eq 124 ]]; then
+    echo "$(date -u --rfc-3339=seconds) - Timed out waiting for result of $CMD"
+    exit 1
+  fi
+}
+
+function execute() {
+  local CMD="${*}"
+
+  # API server occasionally becomes unavailable, so we repeat command in case of error
+  while true; do
+    ret=0
+    ${CMD} || ret="$?"
+
+    if [[ ret -eq 0 ]]; then
+      return
+    fi
+
+    echo "$(date -u --rfc-3339=seconds) - Command returned error $ret, retrying..."
+  done
+}
+export -f execute
+
+applyFeatureGate
+waitFor 30m ClusterPlatformOperatorPodsCreated
+waitForClusterPlatformOperatorPodsReadiness
+waitForClusterOperatorsRollout


### PR DESCRIPTION
Adds a hack script that's responsible for enabling TP features after cluster creation, and ensuring that the PO components roll out correctly. Note: this was copied from the CAPI component's implementation.

This should be a short term hack as the CI workflows that enable tech preview features before cluster creation are currently permafailing.

Signed-off-by: timflannagan <timflannagan@gmail.com>