### PR TITLE
fix: update yq from V3 to v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ manifests: generate yq kustomize
 	@# Move the vendored PlatformOperator CRD from o/api to the manifests folder
 	cp $(ROOT_DIR)/vendor/github.com/openshift/api/platform/v1alpha1/platformoperators.crd.yaml manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
 	@# TODO(tflannag): Remove this hack when https://github.com/openshift/api/pull/1282 merges.
-	${YQ} w -d'*' --inplace --style=double manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml 'metadata.annotations['include.release.openshift.io/self-managed-high-availability']' true
+	${YQ} '.metadata.annotations["include.release.openshift.io/self-managed-high-availability"] = "true"' -i manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml
 
 	@# Move all of the rukpak manifests into the manifests folder
 	$(MV_TMP_DIR)/apiextensions.k8s.io_v1_customresourcedefinition_bundledeployments.core.rukpak.io.yaml manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
@@ -234,4 +234,4 @@ $(KIND): $(LOCALBIN)
 .PHONY: yq
 yq: $(YQ) ## Download yq locally if necessary.
 $(YQ): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install $(GO_INSTALL_OPTS) github.com/mikefarah/yq/v3@$(YQ_VERSION)
+	GOBIN=$(LOCALBIN) go install $(GO_INSTALL_OPTS) github.com/mikefarah/yq/v4@$(YQ_VERSION)


### PR DESCRIPTION
## Summary
This PR updates our usage of `yq` from V3 to V4 to prevent local runs of `make manifests` from failing.