### PR TITLE
Makefile: Ensure a junit report is created when running in CI environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ RBAC_LIST = rbac.authorization.k8s.io_v1_clusterrole_platform-operators-manager-
 	rbac.authorization.k8s.io_v1_clusterrole_platform-operators-rukpak-core-admin.yaml \
 	rbac.authorization.k8s.io_v1_clusterrolebinding_platform-operators-rukpak-core-admin.yaml
 
-
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
 manifests: generate yq kustomize
@@ -125,8 +124,9 @@ e2e: deploy test-e2e
 
 .PHONY: test-e2e
 FOCUS := $(if $(TEST),-v -focus "$(TEST)")
+JUNIT_REPORT := $(if $(ARTIFACT_DIR), -output-dir $(ARTIFACT_DIR) -junit-report junit_e2e.xml)
 test-e2e: ginkgo ## Run e2e tests
-	$(GINKGO) -trace -progress $(FOCUS) test/e2e
+	$(GINKGO) -trace -progress $(JUNIT_REPORT) $(FOCUS) test/e2e
 
 .PHONY: verify
 verify: tidy manifests


### PR DESCRIPTION
Ensure that ginkgo generates a junit report when the $ARTIFACT_DIR environment variable has been specified. This variable is always present when running the testing suite in CI environments.

This was pulled out of the #23 PR which did correctly generate a junit report.

Signed-off-by: timflannagan <timflannagan@gmail.com>