### PR TITLE
controllers: Set Progressing=False during success states

### DIFF
--- a/controllers/aggregated_clusteroperator_controller.go
+++ b/controllers/aggregated_clusteroperator_controller.go
@@ -78,7 +78,7 @@ func (a *AggregatedClusterOperatorReconciler) Reconcile(ctx context.Context, req
 	if len(poList.Items) == 0 {
 		// No POs on cluster, everything is fine
 		coBuilder.WithAvailable(openshiftconfigv1.ConditionTrue, "No POs are present in the cluster", "NoPOsFound")
-		coBuilder.WithProgressing(openshiftconfigv1.ConditionTrue, "No POs are present in the cluster")
+		coBuilder.WithProgressing(openshiftconfigv1.ConditionFalse, "No POs are present in the cluster")
 		return ctrl.Result{}, nil
 	}
 
@@ -90,6 +90,7 @@ func (a *AggregatedClusterOperatorReconciler) Reconcile(ctx context.Context, req
 		return ctrl.Result{}, nil
 	}
 	coBuilder.WithAvailable(openshiftconfigv1.ConditionTrue, "All POs in a successful state", "POsHealthy")
+	coBuilder.WithProgressing(openshiftconfigv1.ConditionFalse, "All POs in a successful state")
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
Moving this out of the #23 PR. This was needed as the aggregate CO was blocking cluster rollout despite reporting an Available=True condition when no POs had been installed.

Signed-off-by: timflannagan <timflannagan@gmail.com>