### PR TITLE
config,manifests: Update the annotations used in the CVO manifests

### DIFF
--- a/config/aggregatedclusteroperator/aggregated_clusteroperator.yaml
+++ b/config/aggregatedclusteroperator/aggregated_clusteroperator.yaml
@@ -2,11 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: aggregated
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
 spec: {}
 status:
   versions:
-    - name: operator
-      version: "0.0.1-snapshot"
+  - name: operator
+    version: "0.0.1-snapshot"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -14,8 +14,9 @@ namePrefix: platform-operators-
 
 # Annotations to add to all resources.
 commonAnnotations:
-  release.openshift.io/feature-set: TechPreviewNoUpgrade
+  release.openshift.io/feature-set: "TechPreviewNoUpgrade"
   include.release.openshift.io/self-managed-high-availability: "true"
+  exclude.release.openshift.io/internal-openshift-hosted: "true"
 
 images:
 - name: quay.io/brancz/kube-rbac-proxy

--- a/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:

--- a/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundledeployments.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null

--- a/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundles.crd.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-rukpak-bundles.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null

--- a/manifests/0000_50_cluster-platform-operator-manager_01-core-ca.cm.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-core-ca.cm.yaml
@@ -3,6 +3,7 @@ data: {}
 kind: ConfigMap
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"

--- a/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-core-admin.sa.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-core-admin.sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core-admin

--- a/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-webhooks-admin.sa.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-rukpak-webhooks-admin.sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-rukpak-webhooks-admin

--- a/manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-controller-manager

--- a/manifests/0000_50_cluster-platform-operator-manager_01-webhook-ca.cm.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_01-webhook-ca.cm.yaml
@@ -3,6 +3,7 @@ data: {}
 kind: ConfigMap
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"

--- a/manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:

--- a/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-core.service.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-core.service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/serving-cert-secret-name: platform-operators-rukpak-core-tls

--- a/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-webhook.service.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_02-rukpak-webhook.service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/serving-cert-secret-name: platform-operators-rukpak-webhook-tls

--- a/manifests/0000_50_cluster-platform-operator-manager_03_rbac.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_03_rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
@@ -85,6 +86,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-metrics-reader
@@ -98,6 +100,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-proxy-role
@@ -119,6 +122,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-manager-rolebinding
@@ -135,6 +139,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-proxy-rolebinding
@@ -151,6 +156,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-leader-election-role
@@ -192,6 +198,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-leader-election-rolebinding
@@ -209,6 +216,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-rukpak-bundle-reader
@@ -222,6 +230,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-rukpak-bundle-uploader
@@ -235,6 +244,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
@@ -328,6 +338,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-rukpak-core-admin

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
@@ -16,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         kubectl.kubernetes.io/default-container: manager
         release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
@@ -19,6 +20,7 @@ spec:
   template:
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
       labels:

--- a/manifests/0000_50_cluster-platform-operator-manager_05-rukpak.validating-webhook-configuration.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_05-rukpak.validating-webhook-configuration.yaml
@@ -2,6 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"

--- a/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   labels:
@@ -16,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         kubectl.kubernetes.io/default-container: manager
         release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator.yaml
@@ -2,7 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-aggregated


### PR DESCRIPTION
Update the CVO manifests, and update the annotations that are used. Removes the ibm cloud cluster profile for the aggregate CO object, excludes the openshift hosted cluster profile from the annotations, and adds a quote around the "TechPreviewNoUpgrade" feature set.

Moving this out of the #23 PR.

Signed-off-by: timflannagan <timflannagan@gmail.com>