### PR TITLE
*: Ensure the aggregate CO controller populates the status.Versions field

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	platformv1alpha1 "github.com/openshift/api/platform/v1alpha1"
 	"github.com/openshift/platform-operators/controllers"
 	"github.com/openshift/platform-operators/internal/applier"
+	"github.com/openshift/platform-operators/internal/clusteroperator"
 	"github.com/openshift/platform-operators/internal/sourcer"
 	//+kubebuilder:scaffold:imports
 )
@@ -98,7 +99,8 @@ func main() {
 
 	// Add Aggregated CO controller to manager
 	if err = (&controllers.AggregatedClusterOperatorReconciler{
-		Client: mgr.GetClient(),
+		Client:         mgr.GetClient(),
+		ReleaseVersion: clusteroperator.GetReleaseVariable(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AggregatedCO")
 		os.Exit(1)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,6 +42,9 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ "ALL" ]
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/controllers/aggregated_clusteroperator_controller.go
+++ b/controllers/aggregated_clusteroperator_controller.go
@@ -35,6 +35,7 @@ import (
 
 type AggregatedClusterOperatorReconciler struct {
 	client.Client
+	ReleaseVersion string
 }
 
 const aggregateCOName = "platform-operators-aggregated"
@@ -70,6 +71,7 @@ func (a *AggregatedClusterOperatorReconciler) Reconcile(ctx context.Context, req
 	coBuilder.WithProgressing(openshiftconfigv1.ConditionTrue, "")
 	coBuilder.WithDegraded(openshiftconfigv1.ConditionFalse)
 	coBuilder.WithAvailable(openshiftconfigv1.ConditionFalse, "", "")
+	coBuilder.WithVersion("operator", a.ReleaseVersion)
 
 	poList := &platformv1alpha1.PlatformOperatorList{}
 	if err := a.List(ctx, poList); err != nil {

--- a/internal/clusteroperator/release.go
+++ b/internal/clusteroperator/release.go
@@ -1,0 +1,16 @@
+package clusteroperator
+
+import "os"
+
+const (
+	defaultVersionValue    = "0.0.1-snapshot"
+	releaseVersionVariable = "RELEASE_VERSION" // OpenShift's env variable for defining the current release
+)
+
+func GetReleaseVariable() string {
+	v := os.Getenv(releaseVersionVariable)
+	if v == "" {
+		return defaultVersionValue
+	}
+	return v
+}

--- a/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
@@ -45,6 +45,9 @@ spec:
         - --leader-elect
         command:
         - /manager
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
         image: controller:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/test/e2e/aggregated_clusteroperator_test.go
+++ b/test/e2e/aggregated_clusteroperator_test.go
@@ -43,6 +43,20 @@ var _ = Describe("aggregated clusteroperator controller", func() {
 				WithTransform(func(c *configv1.ClusterOperatorStatusCondition) string { return c.Message }, ContainSubstring("No POs are present in the cluster")),
 			))
 		})
+		It("should consistently contain a populated status.versions", func() {
+			Consistently(func() (bool, error) {
+				co := &configv1.ClusterOperator{}
+				if err := c.Get(ctx, types.NamespacedName{Name: aggregateCOName}, co); err != nil {
+					return false, err
+				}
+				if len(co.Status.Versions) != 1 {
+					return false, nil
+				}
+				version := co.Status.Versions[0]
+
+				return version.Name != "" && version.Version != "", nil
+			}).Should(BeTrue())
+		})
 	})
 
 	When("installing a series of POs successfully", func() {
@@ -95,6 +109,21 @@ var _ = Describe("aggregated clusteroperator controller", func() {
 				WithTransform(func(c *configv1.ClusterOperatorStatusCondition) string { return c.Reason }, Equal("POsHealthy")),
 				WithTransform(func(c *configv1.ClusterOperatorStatusCondition) string { return c.Message }, ContainSubstring("All POs in a successful state")),
 			))
+		})
+
+		It("should consistently contain a populated status.versions", func() {
+			Consistently(func() (bool, error) {
+				co := &configv1.ClusterOperator{}
+				if err := c.Get(ctx, types.NamespacedName{Name: aggregateCOName}, co); err != nil {
+					return false, err
+				}
+				if len(co.Status.Versions) != 1 {
+					return false, nil
+				}
+				version := co.Status.Versions[0]
+
+				return version.Name != "" && version.Version != "", nil
+			}).Should(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
Ensure the aggregated platform operator CO resource has a populated status.Versions field. By default, the YAML manifest for this resource has a populated status.Version but the aggregate CO controller logic stomps on this value during reconciliation. Update that reconciliation logic to ensure this value is persisted during events.

Signed-off-by: timflannagan <timflannagan@gmail.com>