### PR TITLE
Introduce platform operators to the OCP payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN make build
 FROM registry.ci.openshift.org/ocp/4.12:base
 
 COPY manifests /manifests
-# LABEL io.openshift.release.operator=true
+LABEL io.openshift.release.operator=true
 
 COPY --from=builder /build/bin/manager /
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ manifests: generate yq kustomize
 	ls $(TMP_DIR)
 
 	@# Cleanup the existing manifests so no removed ones linger post generation
-	rm manifests/* || true
+	rm manifests/*.yaml || true
 
 	@# Move the vendored PlatformOperator CRD from o/api to the manifests folder
 	cp $(ROOT_DIR)/vendor/github.com/openshift/api/platform/v1alpha1/platformoperators.crd.yaml manifests/0000_50_cluster-platform-operator-manager_00-platformoperator.crd.yaml

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,16 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-platform-operators-manager
+    from:
+      kind: DockerImage
+      name: controller:latest
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+  - name: olm-rukpak
+    from:
+      kind: DockerImage
+      name: quay.io/operator-framework/rukpak:main


### PR DESCRIPTION
Introduces platform operators to the OCP payload. The CPOM and rukpak components will only be present when the "TechPreviewNoUpgrades" feature set has been enabled.

See [the [OLM-2668](https://issues.redhat.com//browse/OLM-2668) gist](https://gist.github.com/timflannagan/5490dc7471831da11772cd695512b863) for more information.