### PR TITLE
OLM-2761: Add validation for package uniqueness

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -23,6 +23,8 @@ import (
 var (
 	TypeInstalled = "Installed"
 
+	ReasonValidationFailed = "ValidationFailed"
+
 	ReasonSourceFailed  = "SourceFailed"
 	ReasonUnpackPending = "UnpackPending"
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,29 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	platformv1alpha1 "github.com/openshift/api/platform/v1alpha1"
+)
+
+func UniquePackage(ctx context.Context, cli client.Client, po *platformv1alpha1.PlatformOperator) error {
+	existingPlatformOperators := &platformv1alpha1.PlatformOperatorList{}
+	if err := cli.List(ctx, existingPlatformOperators); err != nil {
+		return err
+	}
+
+	for _, otherPO := range existingPlatformOperators.Items {
+		if otherPO.Spec.Package.Name == po.Spec.Package.Name {
+			return fmt.Errorf(
+				"%v spec.package.name is not unique, conflicts with PlatformOperator %v",
+				po.Name,
+				otherPO.Name,
+			)
+		}
+	}
+
+	return nil
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -9,18 +9,25 @@ import (
 	platformv1alpha1 "github.com/openshift/api/platform/v1alpha1"
 )
 
+// UniquePackage checks that the provided PlatformOperator contains a unique spec.package.name
+// when compared to the other PlatformOperators existing on cluster.
 func UniquePackage(ctx context.Context, cli client.Client, po *platformv1alpha1.PlatformOperator) error {
 	existingPlatformOperators := &platformv1alpha1.PlatformOperatorList{}
 	if err := cli.List(ctx, existingPlatformOperators); err != nil {
 		return err
 	}
 
-	for _, otherPO := range existingPlatformOperators.Items {
-		if otherPO.Spec.Package.Name == po.Spec.Package.Name {
+	for _, existingPO := range existingPlatformOperators.Items {
+		// check whether we're processing the same PlatformOperator as the parameter
+		if existingPO.GetName() == po.GetName() {
+			continue
+		}
+
+		if existingPO.Spec.Package.Name == po.Spec.Package.Name {
 			return fmt.Errorf(
 				"%v spec.package.name is not unique, conflicts with PlatformOperator %v",
 				po.Name,
-				otherPO.Name,
+				existingPO.Name,
 			)
 		}
 	}


### PR DESCRIPTION
# Summary
## Context
There are two things at play for this PR:

1. The PlatformOperator's name
2. The PlatformOperator's `spec.package.name`

## Before

Prior to this PR if two PlatformOperators had different names but the same `spec.package.name` then we would allow them to both get created and the underlying RukPak logic would surface up a collision between them. 

## After
With this PR we are now making it so the core reconciliation loop of the PlatformOperator controller detects when an update would result in a duplicate `spec.package.name` being installed. Instead of allowing the collision to occur during installation we instead now surface a clearer error indicating that a collision would occur.