### PR TITLE
test/e2e: Use foreground cascading deletion

### DIFF
--- a/test/e2e/aggregated_clusteroperator_test.go
+++ b/test/e2e/aggregated_clusteroperator_test.go
@@ -87,7 +87,7 @@ var _ = Describe("aggregated clusteroperator controller", func() {
 		})
 		AfterEach(func() {
 			Expect(HandleTestCaseFailure()).To(BeNil())
-			Expect(c.Delete(ctx, po)).To(BeNil())
+			Expect(c.Delete(ctx, po, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
 		})
 
 		It("should eventually result in a successful application", func() {
@@ -156,7 +156,7 @@ var _ = Describe("aggregated clusteroperator controller", func() {
 		})
 		AfterEach(func() {
 			Expect(HandleTestCaseFailure()).To(BeNil())
-			Expect(c.Delete(ctx, po)).To(BeNil())
+			Expect(c.Delete(ctx, po, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
 		})
 
 		It("should eventually result in a failed attempt at sourcing that non-existent package", func() {
@@ -223,8 +223,8 @@ var _ = Describe("aggregated clusteroperator controller", func() {
 		})
 		AfterEach(func() {
 			Expect(HandleTestCaseFailure()).To(BeNil())
-			Expect(c.Delete(ctx, invalid)).To(BeNil())
-			Expect(c.Delete(ctx, valid)).To(BeNil())
+			Expect(c.Delete(ctx, invalid, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
+			Expect(c.Delete(ctx, valid, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
 		})
 
 		It("should eventually result in a failed attempt at sourcing that non-existent package", func() {

--- a/test/e2e/platform_operators_test.go
+++ b/test/e2e/platform_operators_test.go
@@ -43,7 +43,7 @@ var _ = Describe("platform operators controller", func() {
 		})
 		AfterEach(func() {
 			Expect(HandleTestCaseFailure()).To(BeNil())
-			Expect(c.Delete(ctx, po)).To(BeNil())
+			Expect(c.Delete(ctx, po, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
 		})
 		It("should generate a Bundle Deployment with a metadata.Name that matches the platformoperator's metadata.Name", func() {
 			Eventually(func() error {
@@ -151,7 +151,7 @@ var _ = Describe("platform operators controller", func() {
 		})
 		AfterEach(func() {
 			Expect(HandleTestCaseFailure()).To(BeNil())
-			Expect(c.Delete(ctx, po)).To(BeNil())
+			Expect(c.Delete(ctx, po, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
 		})
 
 		It("should eventually result in a failed attempt at sourcing that non-existent package", func() {
@@ -188,7 +188,7 @@ var _ = Describe("platform operators controller", func() {
 		})
 		AfterEach(func() {
 			Expect(HandleTestCaseFailure()).To(BeNil())
-			Expect(c.Delete(ctx, po)).To(BeNil())
+			Expect(c.Delete(ctx, po, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(BeNil())
 		})
 
 		It("should eventually result in a failed attempt at applying the unpacked contents", func() {


### PR DESCRIPTION
When deleting any PlatformOperator or BundleDeployment resources, specify the foreground cascading deletion propagation policy in relevant client usage in the e2e suite.

This should cut down on the number of flakes that result in failed installations due to tests re-using the same PlatformOperator package name. The issue here is we don't give the underlying cascading deletion enough time to fully uninstall before we attempt a new installation. And the result here is that the BundleDeployment installation fails as some resources already exist and cannot be successfully adopted.

Signed-off-by: timflannagan <timflannagan@gmail.com>