### PR TITLE
Ensure downstream CI can run envtest successfully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,10 @@ lint: golangci-lint
 	GOLANGCI_LINT_CACHE=/tmp/golangci-cache $(GOLANGCI_LINT) run
 
 UNIT_TEST_DIRS=$(shell go list ./... | grep -v /test/)
+ENVTEST_OPTS ?= $(if $(OPENSHIFT_CI),--bin-dir=/tmp)
 .PHONY: unit
 unit: generate envtest ## Run unit tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -count=1 -short $(UNIT_TEST_DIRS)
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) $(ENVTEST_OPTS) -p path)" go test -count=1 -short $(UNIT_TEST_DIRS)
 
 .PHONY: e2e
 e2e: deploy test-e2e

--- a/controllers/aggregated_clusteroperator_controller_test.go
+++ b/controllers/aggregated_clusteroperator_controller_test.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/openshift/platform-operators/internal/clusteroperator"
+)
+
+var _ = Describe("Aggregated ClusterOperator Controller", func() {
+	var (
+		r *AggregatedClusterOperatorReconciler
+	)
+	BeforeEach(func() {
+		r = &AggregatedClusterOperatorReconciler{
+			Client: c,
+		}
+	})
+	It("should successfully reconcile when no platformoperators exist on the cluster", func() {
+		_, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: clusteroperator.AggregateResourceName,
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,12 +17,19 @@ limitations under the License.
 package controllers
 
 import (
-	"path/filepath"
+	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -32,43 +39,68 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-var k8sClient client.Client
-var testEnv *envtest.Environment
+var (
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+	scheme  *runtime.Scheme
+	c       client.Client
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+	SetDefaultEventuallyTimeout(30 * time.Second)
+	SetDefaultEventuallyPollingInterval(1 * time.Second)
 
 	RunSpecs(t, "Controller suite")
 }
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{"../manifests", "../vendor/github.com/openshift/api/config/v1/"},
 		ErrorIfCRDPathMissing: true,
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = platformv1alpha1.Install(scheme.Scheme)
+	scheme = runtime.NewScheme()
+
+	err = platformv1alpha1.Install(scheme)
 	Expect(err).NotTo(HaveOccurred())
+
+	err = configv1.Install(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = rukpakv1alpha1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	err = operatorsv1alpha1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	err = corev1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	c, err = client.New(cfg, client.Options{
+		Scheme: scheme,
+	})
+	Expect(err).To(BeNil())
 
 	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
 })
 
 var _ = AfterSuite(func() {
+	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Closes #70.

Updates the Makefile invocation when running the unit tests to ensure we're able to install the requisite envtest executables in a directory path that's writable in CI. Add a barebones testing suite to ensure we're not regressing on envtest capability.