### PR TITLE
test/e2e: Preserve the existing environment when using exec.Command

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -37,12 +37,13 @@ func HandleTestCaseFailure() error {
 	cmd := exec.Command("/bin/bash", "-c", "./collect-ci-artifacts.sh")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(cmd.Env, []string{
+	envVars := []string{
 		"ARTIFACT_DIR=" + testCaseDir,
 		"KUBECONFIG=" + os.Getenv("KUBECONFIG"),
 		"KUBECTL=" + os.Getenv("KUBECTL"),
 		"OPENSHIFT_CI=" + os.Getenv("OPENSHIFT_CI"),
-	}...)
+	}
+	cmd.Env = append(os.Environ(), envVars...)
 
 	return cmd.Run()
 }


### PR DESCRIPTION
Ensure we're preserving the existing environment before running any exec.Commands. I noticed locally when running the e2e suite that the underlying bash script wasn't able to find 'oc' despite that executable being in my $PATH, and the `which oc` was outputting strange results when run in isolation. Explicitly specifying the existing environment via `os.Environ()` which should include the $PATH variable helped fix this pathing issue.

Signed-off-by: timflannagan <timflannagan@gmail.com>