### PR TITLE
	OCPBUGS-10333: feat: add workload pinning annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ ENVTEST_VERSION ?= latest
 GINKGO_VERSION ?= v2.1.4
 GOLANGCI_LINT_VERSION ?= v1.48.0
 KIND_VERSION ?= v0.14.0
-YQ_VERSION ?= latest
+YQ_VERSION ?= v4.30.8
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -41,12 +41,40 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
+# Adding the workload pinning annotation to all deployment pod templates.
+# This allows the workload pinning webhook to know which pods to modify
+# with the specific custom resources for workload pinning to work.
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: platform-operators-*
+    spec:
+      template:
+        metadata:
+          annotations:
+            target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}' 
+  target:
+    kind: Deployment
+
+# Adding the workload pinning annotation to the namespace.
+# In order for any workload pinned pod to run in this namespace, the below
+# annotation is required.
+- patch: |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      annotations:
+        workload.openshift.io/allowed: "management"
+      name: openshift-*
+  target:
+    kind: Namespace
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml

--- a/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_00-namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
+    workload.openshift.io/allowed: management
   labels:
     control-plane: controller-manager
     pod-security.kubernetes.io/enforce: baseline

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-core.deployment.yaml
@@ -23,6 +23,7 @@ spec:
         include.release.openshift.io/single-node-developer: "true"
         kubectl.kubernetes.io/default-container: manager
         release.openshift.io/feature-set: TechPreviewNoUpgrade
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: core
     spec:

--- a/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_04-rukpak-webhooks.deployment.yaml
@@ -25,6 +25,7 @@ spec:
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
         release.openshift.io/feature-set: TechPreviewNoUpgrade
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: webhooks
     spec:

--- a/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         include.release.openshift.io/single-node-developer: "true"
         kubectl.kubernetes.io/default-container: manager
         release.openshift.io/feature-set: TechPreviewNoUpgrade
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         control-plane: controller-manager
     spec:


### PR DESCRIPTION
Adding annotations to namespace and deployment to support the workload pinning enhancement.

These annotations are used to modify the resources and correctly assign workloads to specific cpu sets when the cluster is configured for CPU partitioning.

https://github.com/openshift/enhancements/pull/703
https://github.com/openshift/enhancements/pull/1213



