### PR TITLE
bump golangci-lint to 1.51.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN_DIR := bin
 CONTAINER_RUNTIME ?= docker
 KUBECTL ?= kubectl
 KIND_CLUSTER_NAME ?= kind
-GO_INSTALL_OPTS ?= "-mod=readonly"
+GO_INSTALL_OPTS ?= "-mod=mod"
 TMP_DIR := $(shell mktemp -d -t manifests-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 MV_TMP_DIR := mv $(TMP_DIR)
 
@@ -177,7 +177,7 @@ KUSTOMIZE_VERSION ?= v4.2.0
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 ENVTEST_VERSION ?= latest
 GINKGO_VERSION ?= v2.1.4
-GOLANGCI_LINT_VERSION ?= v1.48.0
+GOLANGCI_LINT_VERSION ?= v1.51.0
 KIND_VERSION ?= v0.14.0
 YQ_VERSION ?= v4.30.8
 

--- a/internal/controllers/platformoperator_controller.go
+++ b/internal/controllers/platformoperator_controller.go
@@ -134,7 +134,7 @@ func (r *PlatformOperatorReconciler) ensureDesiredBundleDeployment(ctx context.C
 		}
 		sourcedBundle, err := r.Sourcer.Source(ctx, po)
 		if err != nil {
-			return nil, fmt.Errorf("%v: %w", err, errSourceFailed)
+			return nil, fmt.Errorf("%v: %w", err, errSourceFailed) //nolint:errorlint
 		}
 		bd = applier.NewBundleDeployment(po, sourcedBundle.Image)
 		if err := r.Create(ctx, bd); err != nil {


### PR DESCRIPTION
We need to bump golangci-lint to at least 1.50 to be able to bump to go 1.20.