### PR TITLE
OCPBUGS-22457: manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator: Drop namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ manifests: generate $(YQ) $(KUSTOMIZE)
 	$(MV_TMP_DIR)/v1_service_platform-operators-controller-manager-metrics-service.yaml manifests/0000_50_cluster-platform-operator-manager_02-metricsservice.yaml
 	$(MV_TMP_DIR)/apps_v1_deployment_platform-operators-controller-manager.yaml manifests/0000_50_cluster-platform-operator-manager_06-deployment.yaml
 	$(MV_TMP_DIR)/config.openshift.io_v1_clusteroperator_platform-operators-aggregated.yaml manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator.yaml
+	sed -i '/^  namespace:/d' manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator.yaml
 
 	@# cluster-platform-operator-manager rbacs
 	rm -f manifests/0000_50_cluster-platform-operator-manager_03_rbac.yaml

--- a/manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator.yaml
+++ b/manifests/0000_50_cluster-platform-operator-manager_07-aggregated-clusteroperator.yaml
@@ -7,7 +7,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: platform-operators-aggregated
-  namespace: openshift-platform-operators
 spec: {}
 status:
   relatedObjects:


### PR DESCRIPTION
[ClusterOperator is a cluster-scoped resource][1], so there is no point in requesting a `namespace`.

[1]: https://github.com/openshift/api/blob/b8a18fdc040de6208d49111ac776ac08b98e6bb7/config/v1/types_cluster_operator.go#L9