### PR TITLE
Makefile: Drop yq prerequisite from 'manifests' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ RBAC_LIST = rbac.authorization.k8s.io_v1_clusterrole_platform-operators-manager-
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
-manifests: generate $(YQ) $(KUSTOMIZE)
+manifests: generate $(KUSTOMIZE)
 	$(KUSTOMIZE) build config/default -o $(TMP_DIR)/
 	ls $(TMP_DIR)
 


### PR DESCRIPTION
3dd23a9b68 (#64) removed the final consumer. Subsequently 39662d60ca (#95) removed some other related targets and the `YQ` variable definition.  But this `manifests` prereq snuck through, until this commit, where I'm removing it.