### PR TITLE
OPRUN-3337: Remove platform-operators from the OCP payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN make build
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 
 COPY manifests /manifests
-LABEL io.openshift.release.operator=true
+#LABEL io.openshift.release.operator=true
 
 COPY --from=builder /build/bin/manager /
 USER 1001


### PR DESCRIPTION
Platform Operators is not currently a priority for the Operator Framework group, and its continued presence and dependence on Rukpak is forcing us to spend time keeping Platform Operators up to date. In order to remain focused on delivering OLMv1, we are removing Platform Operators from OCP. 

It is only enabled under the `TechPreviewNoUpgrade` feature gate, so its removal is not expected to have an impact on production systems.